### PR TITLE
Worker ack timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,20 @@ version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "humantime"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "humantime-serde"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "humantime 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hyper"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +453,7 @@ dependencies = [
  "config 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "faux 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime-serde 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "machine 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1154,6 +1169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1361,6 +1377,8 @@ dependencies = [
 "checksum http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
 "checksum http-body 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+"checksum humantime 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9b6c53306532d3c8e8087b44e6580e10db51a023cf9b433cea2ac38066b92da"
+"checksum humantime-serde 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f1c57351e2c81b7a03e82a6c8f4198b309c158f6d67c4adb707af6af7d91465a"
 "checksum hyper 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e7b15203263d1faa615f9337d79c1d37959439dc46c2b4faab33286fadc2a1c5"
 "checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 "checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,13 @@ slog-logfmt = "0.1.0"
 slog-json = "2.3.0"
 slog-async = "2.5.0"
 slog-scope = "4.3.0"
-tokio = {version = "0.2.16", features = ["io-util", "uds", "time", "rt-core", "macros", "sync"] }
+tokio = {version = "0.2.16", features = ["io-util", "uds", "time", "rt-core", "macros", "sync", "stream"] }
 machine = "0.3.0"
 async-trait = "0.1.29"
 uuid = {version = "0.8.1", features = ["v4"] }
 prctl = "1.0.0"
 hyper = "0.13.3"
+humantime-serde = "1.0.0"
 
 [dev-dependencies]
 rusty-fork = "0.2.2"

--- a/example_configs/forkexec_continually_restarting_sleeper.toml
+++ b/example_configs/forkexec_continually_restarting_sleeper.toml
@@ -1,6 +1,7 @@
 [log]
 output = "stderr"
 level = "debug"
+format = { format = "json" }
 
 [supervisor]
 name = "continually-restarting-sleeper"
@@ -14,4 +15,5 @@ type = "program"
 cmdline = ["bundle", "exec", "--gemfile", "gems/kleinhirn_loader/examples/sleeper_agent/Gemfile", "--keep-file-descriptors",
            "ruby", "gems/kleinhirn_loader/examples/sleeper_agent/sleeper_agent.rb"]
 ack_workers = true
+ack_timeout = "400ms"
 env = {}

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,9 +1,14 @@
+use futures::stream::empty;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::{
     net::SocketAddr,
     path::{Path, PathBuf},
     time::Duration,
+};
+use tokio::{
+    stream::Stream,
+    time::{interval, Instant},
 };
 
 #[derive(Deserialize)]
@@ -151,6 +156,20 @@ pub struct WorkerConfig {
 
     #[serde(flatten)]
     pub kind: WorkerKind,
+
+    #[serde(default)]
+    #[serde(with = "humantime_serde")]
+    pub ack_timeout: Option<Duration>,
+}
+
+impl WorkerConfig {
+    pub fn ack_ticker(&self) -> Box<dyn Stream<Item = Instant> + Unpin> {
+        if let Some(timeout) = self.ack_timeout {
+            Box::new(interval(timeout / 2))
+        } else {
+            Box::new(empty())
+        }
+    }
 }
 
 fn default_count() -> usize {
@@ -167,9 +186,6 @@ pub struct Program {
 
     #[serde(default)]
     pub ack_workers: bool,
-
-    #[serde(default)]
-    pub ack_timeout: Option<Duration>,
 }
 
 #[derive(Deserialize)]

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::{
     net::SocketAddr,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 #[derive(Deserialize)]
@@ -166,6 +167,9 @@ pub struct Program {
 
     #[serde(default)]
     pub ack_workers: bool,
+
+    #[serde(default)]
+    pub ack_timeout: Option<Duration>,
 }
 
 #[derive(Deserialize)]

--- a/src/process_control.rs
+++ b/src/process_control.rs
@@ -4,10 +4,20 @@ use uuid::Uuid;
 
 /// A message that updates the supervisor on the state of a child
 /// process.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 pub enum Message {
-    Launched { id: String, pid: u32 },
-    Ack { id: String },
+    Launched {
+        id: String,
+        pid: u32,
+    },
+    Ack {
+        id: String,
+    },
+    LaunchError {
+        id: String,
+        pid: Option<u32>,
+        error: anyhow::Error,
+    },
 }
 
 #[async_trait]

--- a/src/worker_set.rs
+++ b/src/worker_set.rs
@@ -86,7 +86,7 @@ impl State {
                     }
                 })
                 .collect();
-            if ack_timeouts.len() > 0 {
+            if !ack_timeouts.is_empty() {
                 warn!("timed out waiting for an ack from workers"; "workers" => ?ack_timeouts);
                 return WorkerSet::faulted(self);
             }

--- a/src/worker_set.rs
+++ b/src/worker_set.rs
@@ -193,12 +193,12 @@ impl WorkerAcked {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct WorkerAckTimeout {
-    id: String,
+pub struct WorkerLaunchFailure {
+    id: Option<String>,
 }
 
-impl WorkerAckTimeout {
-    pub fn new(id: String) -> Self {
+impl WorkerLaunchFailure {
+    pub fn new(id: Option<String>) -> Self {
         Self { id }
     }
 }
@@ -215,7 +215,7 @@ transitions!(WorkerSet, [
     (Startup, WorkerRequested) => Startup,
     (Startup, WorkerLaunched) => Startup,
     (Startup, WorkerAcked) => [Running, Startup],
-    (Startup, WorkerAckTimeout) => Faulted,
+    (Startup, WorkerLaunchFailure) => Faulted,
     (Startup, WorkerDeath) => [Startup, Faulted],
     (Startup, MiserableCondition) => Faulted,
 
@@ -226,7 +226,7 @@ transitions!(WorkerSet, [
     (Underprovisioned, WorkerRequested) => Underprovisioned,
     (Underprovisioned, WorkerLaunched) => Underprovisioned,
     (Underprovisioned, WorkerAcked) => [Running, Underprovisioned],
-    (Underprovisioned, WorkerAckTimeout) => Faulted,
+    (Underprovisioned, WorkerLaunchFailure) => Faulted,
     (Underprovisioned, WorkerDeath) => [Underprovisioned, Faulted],
     (Underprovisioned, MiserableCondition) => Faulted
 ]);
@@ -276,7 +276,8 @@ impl Startup {
         state.handle_ack(s.id, WorkerSet::startup, WorkerSet::running)
     }
 
-    fn on_worker_ack_timeout(self, t: WorkerAckTimeout) -> Faulted {
+    fn on_worker_launch_failure(self, _t: WorkerLaunchFailure) -> Faulted {
+        // TODO: mark worker as broken
         Faulted { state: self.state }
     }
 
@@ -334,7 +335,8 @@ impl Underprovisioned {
         state.handle_ack(s.id, WorkerSet::underprovisioned, WorkerSet::running)
     }
 
-    fn on_worker_ack_timeout(self, t: WorkerAckTimeout) -> Faulted {
+    fn on_worker_launch_failure(self, _t: WorkerLaunchFailure) -> Faulted {
+        // TODO: mark worker as broken
         Faulted { state: self.state }
     }
 


### PR DESCRIPTION
This fixes #17 - with this change, the supervisor regularly checks if all workers have acked, and if any have exceeded their ack timeout, will mark the state machine as faulty (and report unhealth).